### PR TITLE
``行内代码块的显示

### DIFF
--- a/source/css/_partial/highlight.styl
+++ b/source/css/_partial/highlight.styl
@@ -35,7 +35,7 @@ $line-numbers
     text-shadow: 0 1px #fff
     font-size:  0.85em
     padding: 0 0.3em
-    border: 1px solid #f8f8f8
+    border: 1px solid #dcdcdc
     border-radius: 3px
   pre
     @extend $code-block


### PR DESCRIPTION
现在的问题是``里面的字体比外部的好像大了一点，然后我改了字体和颜色显示。我也是瞎改，没学过CSS
![image](https://cloud.githubusercontent.com/assets/7238866/3744550/a76e413c-1792-11e4-9110-19008437f9a6.png)
