### PR TITLE
修复百度分享问题

### DIFF
--- a/layout/_partial/after-footer.ejs
+++ b/layout/_partial/after-footer.ejs
@@ -42,7 +42,17 @@ var duoshuoQuery = {short_name:"<%= config.duoshuo_shortname || theme.duoshuo_sh
     <a class="article-share-more" data-cmd="more" title="更多"></a>
   </div>
 </div>
-<script>window._bd_share_config={"common":{},"share":{"bdCustomStyle":"<%- url_for("/css/bdshare.css") %>"}};with(document)0[(getElementsByTagName('head')[0]||body).appendChild(createElement('script')).src='http://bdimg.share.baidu.com/static/api/js/share.js?cdnversion='+~(-new Date()/36e5)];</script>
+<script>
+  function SetShareData(cmd, config) {
+    if (shareDataTitle) {
+      config.bdText = shareDataTitle;
+      if (shareDataUrl) {
+        config.bdUrl = shareDataUrl;
+      }
+    }
+    return config;
+  }
+window._bd_share_config={"common":{onBeforeClick: SetShareData},"share":{"bdCustomStyle":"<%- url_for("/css/bdshare.css") %>"}};with(document)0[(getElementsByTagName('head')[0]||body).appendChild(createElement('script')).src='http://bdimg.share.baidu.com/static/api/js/share.js?cdnversion='+~(-new Date()/36e5)];</script>
 <% } %>
 <!-- 百度分享 end -->
 

--- a/layout/_partial/after-footer.ejs
+++ b/layout/_partial/after-footer.ejs
@@ -52,7 +52,12 @@ var duoshuoQuery = {short_name:"<%= config.duoshuo_shortname || theme.duoshuo_sh
     }
     return config;
   }
-window._bd_share_config={"common":{onBeforeClick: SetShareData},"share":{"bdCustomStyle":"<%- url_for("/css/bdshare.css") %>"}};with(document)0[(getElementsByTagName('head')[0]||body).appendChild(createElement('script')).src='http://bdimg.share.baidu.com/static/api/js/share.js?cdnversion='+~(-new Date()/36e5)];</script>
+  window._bd_share_config={
+    "common":{onBeforeClick: SetShareData},
+    "share":{"bdCustomStyle":"<%- url_for("/css/bdshare.css") %>"}
+  };
+  with(document)0[(getElementsByTagName('head')[0]||body).appendChild(createElement('script')).src='http://bdimg.share.baidu.com/static/api/js/share.js?cdnversion='+~(-new Date()/36e5)];
+</script>
 <% } %>
 <!-- 百度分享 end -->
 

--- a/layout/_partial/after-footer.ejs
+++ b/layout/_partial/after-footer.ejs
@@ -44,11 +44,9 @@ var duoshuoQuery = {short_name:"<%= config.duoshuo_shortname || theme.duoshuo_sh
 </div>
 <script>
   function SetShareData(cmd, config) {
-    if (shareDataTitle) {
+    if (shareDataTitle && shareDataUrl) {
       config.bdText = shareDataTitle;
-      if (shareDataUrl) {
-        config.bdUrl = shareDataUrl;
-      }
+      config.bdUrl = shareDataUrl;
     }
     return config;
   }

--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -24,7 +24,7 @@
     </div>
     <footer class="article-footer">
       <% if (config.baidushare || theme.baidushare){ %>
-        <a data-url="<%- post.permalink %>" data-id="<%= post._id %>" class="article-share-link" data-share="baidu"><%= __('share') %></a>
+        <a data-url="<%- post.permalink %>" data-id="<%= post._id %>" class="article-share-link" data-share="baidu" data-title="<%= post.title %>"><%= __('share') %></a>
       <% } else { %>
         <a data-url="<%- post.permalink %>" data-id="<%= post._id %>" class="article-share-link"><%= __('share') %></a>
       <% } %>

--- a/source/js/script.js
+++ b/source/js/script.js
@@ -66,6 +66,8 @@
     var $this = $(this),
       type = $this.attr('data-share'),
       offset = $this.offset();
+      shareDataUrl = $this.attr('data-url');
+      shareDataTitle = $this.attr('data-title');
 
     if (type == 'baidu') {
       var box = $('#article-share-box');

--- a/source/js/script.js
+++ b/source/js/script.js
@@ -66,11 +66,11 @@
     var $this = $(this),
       type = $this.attr('data-share'),
       offset = $this.offset();
-      shareDataUrl = $this.attr('data-url');
-      shareDataTitle = $this.attr('data-title');
 
     if (type == 'baidu') {
       var box = $('#article-share-box');
+      shareDataUrl = $this.attr('data-url');
+      shareDataTitle = $this.attr('data-title');
 
       if (box.hasClass('on')){
         box.removeClass('on');


### PR DESCRIPTION
修复，使用百度分享时，在主页点击分享按钮分享的不是对应文章链接，而是主页链接。