### PR TITLE
only load code highlight font if highlight is on

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -29,7 +29,9 @@
     <link rel="icon" href="<%- theme.favicon %>">
   <% } %>
   <%- css('css/style') %>
-  <link href="//fonts.useso.com/css?family=Source+Code+Pro" rel="stylesheet" type="text/css">
+  <% if (config.highlight.enable){ %>
+    <link href="//fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet" type="text/css">
+  <% } %>
   <!--[if lt IE 9]><script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7/html5shiv.min.js"></script><![endif]-->
   <%- partial('google-analytics') %>
 </head>


### PR DESCRIPTION
Can save bandwidth if code highlighting is off.

Also, do you want to change do a different CDN?   I help at jsDelivr, so I can upload the font easy.  We have [many POP servers in China](http://www.jsdelivr.com/features/network-map).  I've heard that googleapis.com sometimes does not work well in China.