### PR TITLE
优化：单页面般的用户体验

### DIFF
--- a/layout/_partial/after-footer.ejs
+++ b/layout/_partial/after-footer.ejs
@@ -61,6 +61,10 @@ var duoshuoQuery = {short_name:"<%= config.duoshuo_shortname || theme.duoshuo_sh
 
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 
+<script src="//cdn.bootcss.com/jquery.pjax/2.0.1/jquery.pjax.min.js"></script>
+<link href="//cdn.bootcss.com/nprogress/0.2.0/nprogress.min.css" rel="stylesheet">
+<script src="//cdn.bootcss.com/nprogress/0.2.0/nprogress.min.js"></script>
+
 <% if ((config.fancybox || theme.fancybox)){ %>
   <%- css('fancybox/jquery.fancybox') %>
   <%- js('fancybox/jquery.fancybox.pack') %>

--- a/source/js/script.js
+++ b/source/js/script.js
@@ -180,4 +180,16 @@
 
     $container.removeClass('mobile-nav-on');
   });
+
+  //==================  pjax && nprogress  =======================
+
+  $(document).pjax('a', '#container', { fragment: '#container' })
+
+  $(document).on('pjax:send', function() {
+    NProgress.start();
+  })
+  $(document).on('pjax:complete', function() {
+    NProgress.done();
+  })
+
 })(jQuery);


### PR DESCRIPTION
1. 使用 pjax 和 nprogress 为博客提供单页面的体验效果
2. 页面静态资源( css 和 js )无需重复加载

关于 pjax 可查看此 GitHub 仓库： [defunkt/jquery-pjax](https://github.com/defunkt/jquery-pjax)